### PR TITLE
fix: make tool work on Windows

### DIFF
--- a/src/Models/Entrypoint.cs
+++ b/src/Models/Entrypoint.cs
@@ -1,0 +1,17 @@
+﻿namespace Ivanize.DotnetTool.Exec
+{
+    public class Entrypoint
+    {
+        public Entrypoint(string executable, string commandOption)
+        {
+            Executable = executable;
+            CommandOption = commandOption;
+        }
+        
+        public string Executable { get; }
+        public string CommandOption { get; }
+
+        public static Entrypoint Windows { get; } = new Entrypoint("cmd.exe", "/c");
+        public static Entrypoint Unix { get; } = new Entrypoint("/bin/bash", "-c");
+    }
+}

--- a/src/Models/Package.cs
+++ b/src/Models/Package.cs
@@ -5,16 +5,19 @@ namespace Ivanize.DotnetTool.Exec
     public class Package
     {
         public string Name { get; private set; }
-        public string Entrypoint { get; private set; }
+        public string Entrypoint => EntrypointObject.Executable;
+        public Entrypoint EntrypointObject { get; }
         public EnvVariable[] Variables { get; set; }
         public Command[] Commands { get; set; }
 
-        public Package(string name, string entrypoint, EnvVariable[] variables, Command[] commands)
+        public Package(string name, Entrypoint entrypoint, EnvVariable[] variables, Command[] commands)
         {
             this.Name = name ?? throw new ArgumentNullException(nameof(name));
-            this.Entrypoint = entrypoint ?? throw new ArgumentNullException(nameof(entrypoint));
+            this.EntrypointObject = entrypoint ?? throw new ArgumentNullException(nameof(entrypoint));
             this.Variables = variables ?? throw new ArgumentNullException(nameof(variables));
             this.Commands = commands ?? throw new ArgumentNullException(nameof(commands));
         }
+        
+        
     }
 }

--- a/src/Services/DefaultEntrypointDetector.cs
+++ b/src/Services/DefaultEntrypointDetector.cs
@@ -4,18 +4,18 @@ namespace Ivanize.DotnetTool.Exec
 {
     public class DefaultEntrypointDetector : IDefaultEntrypointDetector
     {
-        public string GetDefaultEntryPoint()
+        public Entrypoint GetDefaultEntrypoint()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                return "cmd.exe";
+                return Entrypoint.Windows;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                return "/bin/bash";
+                return Entrypoint.Unix;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                return "/bin/bash";
+                return Entrypoint.Unix;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
-                return "/bin/bash";
-
-            return "cmd.exe";
+                return Entrypoint.Unix;
+            
+            return Entrypoint.Unix;
         }
     }
 }

--- a/src/Services/Executor.cs
+++ b/src/Services/Executor.cs
@@ -13,7 +13,7 @@ namespace Ivanize.DotnetTool.Exec
 
         public Executor()
         {
-            this.forwardStdOut = true;
+            this.forwardStdOut = false; // when true, no output printed to console on Windows
             this.OutWriter = Console.Out;
             this.ErrorWriter = Console.Error;
         }
@@ -65,12 +65,15 @@ namespace Ivanize.DotnetTool.Exec
                 scriptText.Append(escapedArgs);
             }
 
+            var commandOption = string.IsNullOrWhiteSpace(package.EntrypointObject.CommandOption)
+                ? string.Empty
+                : $"{package.EntrypointObject.CommandOption} ";
             var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = package.Entrypoint,
-                    Arguments = $"-c \"{scriptText.ToString()}\"",
+                    Arguments = $"{commandOption}\"{scriptText.ToString()}\"",
                     RedirectStandardOutput = (!this.forwardStdOut) ? true : false,
                     RedirectStandardError = (!this.forwardStdOut) ? true : false,
                     UseShellExecute = false,

--- a/src/Services/IDefaultEntrypointDetector.cs
+++ b/src/Services/IDefaultEntrypointDetector.cs
@@ -2,6 +2,6 @@ namespace Ivanize.DotnetTool.Exec
 {
     public interface IDefaultEntrypointDetector
     {
-        string GetDefaultEntryPoint();
+        Entrypoint GetDefaultEntrypoint();
     }
 }

--- a/src/Services/ScriptsFileParser.cs
+++ b/src/Services/ScriptsFileParser.cs
@@ -40,10 +40,10 @@ namespace Ivanize.DotnetTool.Exec
             if (pkgInstance.Env.Any(s => string.IsNullOrWhiteSpace(s.Key))) throw new InvalidDataException("The Variable `name` is required!");
             if (pkgInstance.Commands.Any(s => string.IsNullOrWhiteSpace(s.Key))) throw new InvalidDataException("The Command `name` is required!");
 
-
+            var entryPoint = pkgInstance.EntrypointObject ?? this.defaultEntrypointDetector.GetDefaultEntrypoint();
             var pkg = new Package(
                 pkgInstance.Name,
-                pkgInstance.Entrypoint ?? this.defaultEntrypointDetector.GetDefaultEntryPoint(),
+                pkgInstance.EntrypointObject ?? this.defaultEntrypointDetector.GetDefaultEntrypoint(),
                 pkgInstance.Env.Select(s => new EnvVariable(s.Key, s.Value)).ToArray(),
                 pkgInstance.Commands.Select(s => new Command(s.Key, s.Value)).ToArray());
 
@@ -56,6 +56,23 @@ namespace Ivanize.DotnetTool.Exec
             public string Entrypoint { get; set; }
             public Dictionary<string, string> Env { get; set; }
             public Dictionary<string, string[]> Commands { get; set; }
+
+            public Entrypoint EntrypointObject
+            {
+                get
+                {
+                    if (string.IsNullOrWhiteSpace(Entrypoint))
+                        return null;
+                    
+                    if (Exec.Entrypoint.Windows.Executable.Equals(Entrypoint, StringComparison.OrdinalIgnoreCase))
+                        return Exec.Entrypoint.Windows;
+                    
+                    if (Exec.Entrypoint.Unix.Executable.Equals(Entrypoint, StringComparison.OrdinalIgnoreCase))
+                        return Exec.Entrypoint.Unix;
+
+                    return new Entrypoint(Entrypoint, null);
+                }
+            }
 
             public InternalPackage()
             {

--- a/src/dotnet-exec.csproj
+++ b/src/dotnet-exec.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<PackageId>dotnet-tool-exec</PackageId>
-		<PackageVersion>2.0.3</PackageVersion>
+		<PackageVersion>2.0.4</PackageVersion>
 
 		<Description>Execute custom commands by dotnet</Description>
 		<PackageType>DotnetCliTool</PackageType>

--- a/test/ApplicationTest.cs
+++ b/test/ApplicationTest.cs
@@ -107,7 +107,7 @@ namespace Ivanize.DotnetTool.Exec.Test
         // Internal Mocking Classes
         private class MockedDefaultEntrypointDetector : IDefaultEntrypointDetector
         {
-            public string GetDefaultEntryPoint() => "/bin/bash";
+            public Entrypoint GetDefaultEntrypoint() => Entrypoint.Unix;
         }
     }
 }

--- a/test/ExecutorTest.cs
+++ b/test/ExecutorTest.cs
@@ -24,7 +24,7 @@ namespace Ivanize.DotnetTool.Exec.Test
         {
             var pkg = new Package(
                 name: "Test",
-                entrypoint: "/bin/bash",
+                entrypoint: Entrypoint.Unix, 
                 variables: new EnvVariable[] { },
                 commands: new Command[] { }
             );
@@ -36,7 +36,7 @@ namespace Ivanize.DotnetTool.Exec.Test
         {
             var pkg = new Package(
                 name: "Test",
-                entrypoint: "/bin/bash",
+                entrypoint: Entrypoint.Unix, 
                 variables: new EnvVariable[] { },
                 commands: new Command[] { }
             );
@@ -61,7 +61,7 @@ namespace Ivanize.DotnetTool.Exec.Test
         {
             var pkg = new Package(
                 name: "Test",
-                entrypoint: "/bin/bash",
+                entrypoint: Entrypoint.Unix, 
                 variables: new EnvVariable[] { },
                 commands: new Command[] {
                     new Command("start",new string[]{"dotnet start"})
@@ -87,7 +87,7 @@ namespace Ivanize.DotnetTool.Exec.Test
         {
             var pkg = new Package(
                 name: "Test",
-                entrypoint: "/bin/bash",
+                entrypoint: Entrypoint.Unix, 
                 variables: new EnvVariable[] { },
                 commands: new Command[] {
                     new Command("start",new string[]{"dotnet start"})
@@ -113,7 +113,7 @@ namespace Ivanize.DotnetTool.Exec.Test
         {
             var pkg = new Package(
                 name: "Test",
-                entrypoint: "/bin/bash",
+                entrypoint: Entrypoint.Unix, 
                 variables: new EnvVariable[] { },
                 commands: new Command[] {
                     new Command("start",new string[]{"echo 'Start'"})
@@ -141,7 +141,7 @@ namespace Ivanize.DotnetTool.Exec.Test
         {
             var pkg = new Package(
                 name: "Test",
-                entrypoint: "/bin/bash",
+                entrypoint: Entrypoint.Unix, 
                 variables: new EnvVariable[] { },
                 commands: new Command[] {
                     new Command("start",new string[]{
@@ -172,7 +172,7 @@ namespace Ivanize.DotnetTool.Exec.Test
         {
             var pkg = new Package(
                 name: "Test",
-                entrypoint: "/bin/bash",
+                entrypoint: Entrypoint.Unix, 
                 variables: new EnvVariable[] { },
                 commands: new Command[] {
                     new Command("start",new string[]{"echo 'Start'"})
@@ -200,7 +200,7 @@ namespace Ivanize.DotnetTool.Exec.Test
         {
             var pkg = new Package(
                 name: "Test",
-                entrypoint: "/bin/bash",
+                entrypoint: Entrypoint.Unix, 
                 variables: new EnvVariable[] { },
                 commands: new Command[] {
                     new Command("start",new string[]{"not-existed-command do-something"})
@@ -228,7 +228,7 @@ namespace Ivanize.DotnetTool.Exec.Test
         {
             var pkg = new Package(
                 name: "Test",
-                entrypoint: "/bin/bash",
+                entrypoint: Entrypoint.Unix, 
                 variables: new EnvVariable[] {
                     new EnvVariable("PROJ_NAME","TEST")
                 },

--- a/test/ScriptsFileParserTest.cs
+++ b/test/ScriptsFileParserTest.cs
@@ -122,7 +122,7 @@ namespace Ivanize.DotnetTool.Exec.Test
         // Internal Mocking Classes
         private class MockedDefaultEntrypointDetector : IDefaultEntrypointDetector
         {
-            public string GetDefaultEntryPoint() => "/bin/bash";
+            public Entrypoint GetDefaultEntrypoint() => Entrypoint.Unix;
         }
     }
 }


### PR DESCRIPTION
First of all, thanks @ivanparvaresh for you effort in making this tool! I am happy I was able to find it. Unfortunately, the tool did not run for me on Windows. This PR aims to fix it. Would appreciate your review and any comments.

The problem was that the `Executor` always executed commands with -c as the command option. This works with `/bin/bash` but not with `cmd.exe` on Windows.

- add `Entrypoint` class
- change `DefaultEntrypointDetector` to return `Entrypoint`
- use command option from `Entrypoint` class in `Executor`
- make sure current configuration json does not need to change - no changes made to serialization